### PR TITLE
Fixing error "Unable to resolve provider app_discovery in namespace protobuf"

### DIFF
--- a/src/rebar3_gpb_plugin.app.src
+++ b/src/rebar3_gpb_plugin.app.src
@@ -1,6 +1,6 @@
 {application, rebar3_gpb_plugin, [
         {description, "A rebar3 gpb plugin for compiling .proto files"},
-        {vsn, "1.2.0"},
+        {vsn, "1.2.1"},
         {registered, []},
         {applications,
             [

--- a/src/rebar3_gpb_prv_compile.erl
+++ b/src/rebar3_gpb_prv_compile.erl
@@ -5,7 +5,7 @@
          format_error/1]).
 
 -define(PROVIDER, 'compile').
--define(DEPS, [default, app_discovery]).
+-define(DEPS, [{default, app_discovery}]).
 -define(SHORT_DESC, "Automatically compile Google Protocol Buffer (.proto) ",
                     "files using the gpb compiler").
 -define(DESC,"Configure gpb options (gbp_opts) in your rebar.config, e.g.\n"


### PR DESCRIPTION
Hi.
When I try to 'rebar3 protobuf compile', I get error
===> Unable to resolve provider app_discovery in namespace protobuf

I didn't dug much into rebar3 source code, but this fix is working for me.