### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `o_erl` and `o_hrl` values are relative to the app's location.
 Add a hook to automatically generate modules for your protobuf files and clean them afterwards:
 
     {provider_hooks, [
-        {pre, [
+        {post, [
             {compile, {protobuf, compile}}
             {clean, {protobuf, clean}}
         ]}


### PR DESCRIPTION
If `o_erl` and `o_hrl` is not `src`, `pre` hook will create folder `myapp/_build/default/lib/myapp/src/` first.

As in `default` profile, the `src` is soft linked to `myapp/apps/myapp/src`. So the pre hook will create the `src` folder with only proto source files, avoiding other files to compile.