### PR TITLE
Support proto as dependencies

### DIFF
--- a/src/rebar3_gpb_prv_clean.erl
+++ b/src/rebar3_gpb_prv_clean.erl
@@ -32,7 +32,9 @@ do(State) ->
                 undefined -> rebar_state:project_apps(State);
                 AppInfo   -> [AppInfo]
            end,
-    lists:foreach(fun rebar3_gpb_compiler:clean/1, Apps),
+    lists:foreach(fun(App) ->
+                    rebar3_gpb_compiler:clean(App, State)
+                  end, Apps),
     {ok, State}.
 
 -spec format_error(any()) -> iolist().

--- a/src/rebar3_gpb_prv_compile.erl
+++ b/src/rebar3_gpb_prv_compile.erl
@@ -43,7 +43,9 @@ do(State) ->
             AppInfo ->
                 [AppInfo]
            end,
-    lists:foreach(fun rebar3_gpb_compiler:compile/1, Apps),
+    lists:foreach(fun(App) ->
+                    rebar3_gpb_compiler:compile(App, State)
+                  end, Apps),
     {ok, State}.
 
 -spec format_error(any()) ->  iolist().


### PR DESCRIPTION
By allowing to look for proto files in the
rebar3 deps directory, this is achieved by
specifying the include term as {i, {deps, <some/dir>}}.