### PR TITLE
Support dependencies as proto based include paths

### DIFF
--- a/src/rebar3_gpb_compiler.erl
+++ b/src/rebar3_gpb_compiler.erl
@@ -190,6 +190,8 @@ default_include_opts(AppDir, DepsDir, Opts) ->
                     {i, filename:join(DepsDir, Path)};
                  ({i, Path}) ->
                     {i, filename:join(AppDir, Path)};
+                 ({ipath, {deps, Path}}) ->
+                    {i, filename:join(DepsDir, Path)};
                  ({ipath, Path}) ->
                     {i, filename:join(AppDir, Path)};
                  (Opt) -> Opt


### PR DESCRIPTION
By specifying {ipath, {deps, "/path/to/proto"}}.