### PR TITLE
Adding support for filtering specific proto files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Configure gpb options (example below), full list can consulted on [gpb's project
 ```erlang
 {gpb_opts, [
     {i, "path/to/proto_dir"} | {i, {deps, "relative/path/from/deps/to/proto_dir"}},
+    {r, [list_of_desired_proto_files]},
     {module_name_suffix, "_pb"},
     %{o, "path/to/out_dir"},    %% both .erl and .hrl are generated here
     {o_erl, "path/to/out_src"},

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Configure gpb options (example below), full list can consulted on [gpb's project
 ```erlang
 {gpb_opts, [
     {i, "path/to/proto_dir"} | {i, {deps, "relative/path/from/deps/to/proto_dir"}},
-    {r, [list_of_desired_proto_files]},
+    {f, ["desired_proto_file1.proto"]},
     {module_name_suffix, "_pb"},
     %{o, "path/to/out_dir"},    %% both .erl and .hrl are generated here
     {o_erl, "path/to/out_src"},
@@ -57,12 +57,12 @@ Plugin specific options (can be used together the gpb ones):
 * `{ipath, "path/to/another/proto_dir"}` - paths that are to be added to gpb's
   include path but not searched for .proto files (useful for importing .proto
   files from other .proto).
-* `{i, {deps, "relative/path/from/deps/to/proto_dir"}` - allows you to compile
+* `{i, {deps, "relative/path/from/deps/to/proto_dir"}}` - allows you to compile
   proto files that were declared and fetched as app dependencies, the [rebar_raw_resource](https://github.com/basho/rebar_raw_resource)
   plugin is a good fit for this use case.
-* `{ipath, {deps, "relative/path/from/deps/to/proto_dir"}` - allows you to specify
+* `{ipath, {deps, "relative/path/from/deps/to/proto_dir"}}` - allows you to specify
   proto include paths in the same fashion as the `{i, {deps, _}}` directive.
-
+* `{f, ["file1.proto", "file2.proto"]} - allows you to specify a subset of all proto files found.
 Add the gpb include path (environment tipically is default):
 
     {erl_opts, [{i, "./_build/<environment>/plugins/gpb/include"}]}.

--- a/src/rebar3_gpb_compiler.erl
+++ b/src/rebar3_gpb_compiler.erl
@@ -61,7 +61,7 @@ compile(AppInfo, State) ->
     %% remove the plugin specific options since gpb will not understand them
     GpbOpts = remove_plugin_opts(
                 proto_include_paths(AppDir, Protos,
-                                    default_include_opts(AppDir, DepsDir,
+                  default_include_opts(AppDir, DepsDir,
                       target_erl_opt(TargetErlDir,
                           target_hrl_opt(TargetHrlDir, GpbOpts0))))),
 
@@ -161,7 +161,7 @@ filter_included_proto(Source, Dep, GpbOpts) ->
                                              GpbOpts ++ [to_proto_defs, return]),
     Imports = lists:map(fun(Import0) ->
                           {ok, Import} = gpb_compile:locate_import(Import0, GpbOpts),
-                                filename:absname(Import)
+                          filename:absname(Import)
                         end, lists:usort(gpb_parse:fetch_imports(Defs))),
     case lists:member(Dep, Imports) of
         true -> {true, Source};

--- a/src/rebar3_gpb_prv_compile.erl
+++ b/src/rebar3_gpb_prv_compile.erl
@@ -11,7 +11,7 @@
 -define(DESC,"Configure gpb options (gbp_opts) in your rebar.config, e.g.\n"
              "  {gpb_opts,["
              "    {i, \"path/to/proto_dir\"},"
-             "    {r, \[list of wanted protobuf files\]},"
+             "    {f, \[list of wanted protobuf files\]},"
              "    {module_name_suffix, \"_pb\"},"
              "    {o_erl, \"path/to/out_src\"},"
              "    {o_hrl, \"path/to/out_include\"},"

--- a/src/rebar3_gpb_prv_compile.erl
+++ b/src/rebar3_gpb_prv_compile.erl
@@ -11,6 +11,7 @@
 -define(DESC,"Configure gpb options (gbp_opts) in your rebar.config, e.g.\n"
              "  {gpb_opts,["
              "    {i, \"path/to/proto_dir\"},"
+             "    {r, \[list of wanted protobuf files\]},"
              "    {module_name_suffix, \"_pb\"},"
              "    {o_erl, \"path/to/out_src\"},"
              "    {o_hrl, \"path/to/out_include\"},"


### PR DESCRIPTION
We had a case where the source directory had a ton of proto files, and to reduce unused code we only wanted to compile a few of them @fylke @patrikhuss