### PR TITLE
Use latest OTP 20 and 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+dist: trusty
 sudo: false
 language: erlang
 otp_release:
   - 22.0.2
-  - 21.2.5
-  - 20.2
+  - 21.3
+  - 20.3
   - 19.3
   - 18.3
 


### PR DESCRIPTION
Also specify dist for travis to get Erlang 18 running. This is an attempt to make the travis run ok. For details about specifying the dist, see also the tomas-abrahamsson/gpb@ed1096cc commit.