### PR TITLE
Update doc link to gpb_compile:file/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add the plugin to your rebar config:
 ]}.
 ```
 
-Configure gpb options (example below), full list can consulted on [gpb's project page](https://github.com/tomas-abrahamsson/gpb) [gpb_compile:file/2](https://github.com/tomas-abrahamsson/gpb/blob/3.19.0/src/gpb_compile.erl#L66-L93):
+Configure gpb options (example below), full list can consulted on [gpb's project page](https://github.com/tomas-abrahamsson/gpb) [gpb_compile:file/2](https://hexdocs.pm/gpb/gpb_compile.html#file-2):
 
 ```erlang
 {gpb_opts, [


### PR DESCRIPTION
Point it to [hexdocs](https://hexdocs.pm/gpb) which has the latest version.