### PR TITLE
Replace use of OTP 20+ -specific string:find

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ otp_release:
 before_script:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod u+x rebar3
-script: "./rebar3 update && ./rebar3 compile"
+script: "./rebar3 update && ./rebar3 compile && ./rebar3 dialyzer"

--- a/src/rebar3_gpb_compiler.erl
+++ b/src/rebar3_gpb_compiler.erl
@@ -189,9 +189,9 @@ find_first_match(WantedProto, [Head | RemainingProtos]) ->
 
 
 is_wanted_proto(WantedProto, ProtoPath) ->
-    case string:find(ProtoPath, WantedProto, trailing) of
-        nomatch -> false;
-        _Match -> true
+    case string:sub_string(ProtoPath, length(ProtoPath) - length(WantedProto) + 1) of
+        WantedProto -> true;
+        _Other -> false
     end.
 
 filter_unwanted_protos(WantedProtos, AllProtos) ->


### PR DESCRIPTION
**Main goal**: keep `rebar.config`'s promise of `minimum_otp_version`.

If I understood correctly the goal of the (previous, now-updated) code is to check if a given proto file is part of a given path (that includes the filename). In that case, even though I tried to reach the same goal as the previous code, it might have already been incomplete already, since it would allow `ab.proto` and `b.proto` to be found, for the same search, i.e.

```erlang
1> string:find("protos/ab.proto", "ab.proto", trailing).
"ab.proto"
2> string:find("protos/ab.proto", "b.proto", trailing). 
"b.proto"
```

---

**Note**: `.travis.yml` is changed so this type of issue is visible in future changes.