### PR TITLE
Use gpb_compile:list_io/2 to get target and deps

### DIFF
--- a/src/rebar3_gpb_compiler.erl
+++ b/src/rebar3_gpb_compiler.erl
@@ -119,17 +119,12 @@ discover(AppDir, SourceDir, Opts) ->
 
 compile([], _TargetErlDir, _GpbOpts, _Protos) -> ok;
 compile([Proto | Rest], TargetErlDir, GpbOpts, Protos) ->
-    ModuleNamePrefix = proplists:get_value(module_name_prefix, GpbOpts,
-                                           ?DEFAULT_MODULE_PREFIX),
-    ModuleNameSuffix = proplists:get_value(module_name_suffix, GpbOpts,
-                                           ?DEFAULT_MODULE_SUFFIX),
-    ModuleNameFromOpt = proplists:get_value(module_name, GpbOpts),
-    Target = target_file(Proto, ModuleNamePrefix, ModuleNameSuffix, ModuleNameFromOpt, TargetErlDir),
+    Target = get_target(Proto, GpbOpts),
     Deps =
       case filelib:last_modified(Target) < filelib:last_modified(Proto) of
           true ->
             ok = compile(Proto, Target, GpbOpts),
-            %% now we know that thid proto needed compilation we check
+            %% now we know that this proto needed compilation we check
             %% for other protos that might have included this one and ensure that
             %% those are compiled as well
             Deps0 = get_dependencies(Proto, Protos, GpbOpts),
@@ -137,8 +132,7 @@ compile([Proto | Rest], TargetErlDir, GpbOpts, Protos) ->
               [Proto, Deps0]),
             %% now touch the targets of each of the deps so they get remade again
             lists:foreach(fun(Dep) ->
-                            DepTarget = target_file(Dep, ModuleNamePrefix, ModuleNameSuffix,
-                                                    ModuleNameFromOpt, TargetErlDir),
+                            DepTarget = get_target(Dep, GpbOpts),
                             %% we want to force compilation in this case so we must trick
                             %% the plugin into believing that the proto is more recent than the
                             %% target, this means we need to set the last changed time on the
@@ -155,21 +149,23 @@ compile([Proto | Rest], TargetErlDir, GpbOpts, Protos) ->
       end,
     compile(Rest ++ Deps, TargetErlDir, GpbOpts, Protos).
 
+get_target(Proto, GpbOpts) ->
+    InputsOutputs = gpb_compile:list_io(Proto, GpbOpts),
+    {erl_output, Erl} = lists:keyfind(erl_output, 1, InputsOutputs),
+    Erl.
+
 get_dependencies(Proto, Protos, GpbOpts) ->
     %% go through each of the protos and for each one
     %% check if it included the provided proto, return
-    %% the ones tht do
+    %% the ones that do
     lists:filtermap(fun(Proto0) ->
                       filter_included_proto(Proto0, Proto, GpbOpts)
                     end, Protos).
 
 filter_included_proto(Source, Dep, GpbOpts) ->
-    {ok, Defs, _Warnings} = gpb_compile:file(filename:basename(Source),
-                                             GpbOpts ++ [to_proto_defs, return]),
-    Imports = lists:map(fun(Import0) ->
-                          {ok, Import} = gpb_compile:locate_import(Import0, GpbOpts),
-                          filename:absname(Import)
-                        end, lists:usort(gpb_defs:fetch_imports(Defs))),
+    InputsOutputs = gpb_compile:list_io(Source, GpbOpts),
+    {sources, SourceAndImports} = lists:keyfind(sources, 1, InputsOutputs),
+    Imports = tl(SourceAndImports),
     case lists:member(Dep, Imports) of
         true -> {true, Source};
         false -> false
@@ -198,13 +194,6 @@ filter_unwanted_protos(WantedProtos, AllProtos) ->
     [find_first_match(WantedProto, AllProtos) || WantedProto <- WantedProtos].
 
 
-
-target_file(Proto, ModuleNamePrefix, ModuleNameSuffix, undefined = _ModuleName, TargetErlDir) ->
-    Module = filename:basename(Proto, ".proto"),
-    filename:join([TargetErlDir, ModuleNamePrefix ++ Module ++ ModuleNameSuffix ++ ".erl"]);
-target_file(_Proto, _ModuleNamePrefix, _ModuleNameSuffix, ModuleName, TargetErlDir) ->
-    Module = filename:basename(ModuleName, ".proto"),
-    filename:join([TargetErlDir, Module ++ ".erl"]).
 
 -spec compile(string(), string(), proplists:proplist()) -> ok.
 compile(Source, Target, GpbOpts) ->


### PR DESCRIPTION
Use [`gpb_compile:list_io/2`](https://hexdocs.pm/gpb/gpb_compile.html#list_io-2) to get target output files and dependency file names, to avoid duplicating knowledge of gpb's module renaming options to here.

This addresses #130.

I have only tested this on a very rudimentary level, in a small demo example, so a review might be needed.