### PR TITLE
Shift workflow Erlang version from 22..24 to 23..25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [22, 23, 24]
+        otp_version: [23, 24, 25]
         os: [ubuntu-latest]
 
     steps:

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,6 @@
     {warnings, [
         unmatched_returns,
         error_handling,
-        race_conditions,
         underspecs
     ]}
 ]}.


### PR DESCRIPTION
In the github workflow actions, run on Erlang versions 23..25.

I noticed the [Erlang 22 action for the 4.19.6 pr](https://github.com/lrascao/rebar3_gpb_plugin/actions/runs/3118027104/jobs/5057057303) failed with
```
Run rebar3 update
escript: exception error: undefined function rebar3:main/1
  in function  escript:run/2 (escript.erl, line 758)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1 
  in call from init:do_boot/3 
Error: Process completed with exit code 127.
```
but the actions for Erlang 23 and 24 did not fail this way. So I'm guessing the reason for the error above might be that the erlef rebar3 is built on Erlang 23 or later and the Erlang 22 won't load it.

As an attempt to fix it, This PR drops Erlang 22 and adds Erlang 25.

Also, drop the `race_condition` option to Dialyzer, as it has been [removed in Erlang 25](https://www.erlang.org/patches/otp-25.0#OTP-17819)