### PR TITLE
Fix clean target path derivation

### DIFF
--- a/src/rebar3_gpb_compiler.erl
+++ b/src/rebar3_gpb_compiler.erl
@@ -84,7 +84,7 @@ clean(AppInfo, State) ->
     rebar_api:debug("found proto files: ~p", [ProtoFiles]),
     GeneratedRootFiles =
         lists:usort(
-          [filename:rootname(get_target(ProtoFile, GpbOpts))
+          [filename:rootname(filename:basename(get_target(ProtoFile, GpbOpts)))
            || ProtoFile <- ProtoFiles]),
     GeneratedErlFiles = [filename:join([TargetErlDir, F ++ ".erl"]) ||
                             F <- GeneratedRootFiles],


### PR DESCRIPTION
clean/2 derives generated file roots from the target path returned by gpb_compile:list_io/2, then joins those roots with the configured output directories.

With the sample app configuration in `doc/samples/sample_app/rebar.config`, `proto/addressbook.proto` produces generated files such as:

```text
src/addressbook_pb.erl
include/addressbook_pb.hrl
```

The old clean path calculation used `filename:rootname/1` on the full target returned by gpb. For the sample app, that target is shaped like:

```text
_build/default/lib/sample_app/src/addressbook_pb.erl
```

That root was then joined with the configured output directory again, so clean tried to delete a path shaped like:

```text
_build/default/lib/sample_app/src/_build/default/lib/sample_app/src/addressbook_pb.erl
```

As a result, `rebar3 protobuf clean` completed successfully but left the generated `.erl` and `.hrl` files behind.

This fixes the path derivation by taking the target basename before deriving the generated root name.

Reproduction checked locally:

```sh
cd doc/samples/sample_app
rebar3 compile
test -f src/addressbook_pb.erl
test -f include/addressbook_pb.hrl
rebar3 protobuf clean
test ! -e src/addressbook_pb.erl
test ! -e include/addressbook_pb.hrl
```

Observed result:

```text
lrascao/develop:
  after rebar3 protobuf clean, src/addressbook_pb.erl still exists
  after rebar3 protobuf clean, include/addressbook_pb.hrl still exists

this branch:
  after rebar3 protobuf clean, src/addressbook_pb.erl is removed
  after rebar3 protobuf clean, include/addressbook_pb.hrl is removed
```

Validation:
- `rebar3 compile`
- A/B checked `rebar3 compile` followed by `rebar3 protobuf clean` using `doc/samples/sample_app`

Fixes #176.
