### PR TITLE
Refactor proto discovery

### DIFF
--- a/src/rebar3_gpb_compiler.erl
+++ b/src/rebar3_gpb_compiler.erl
@@ -3,7 +3,6 @@
 -export([compile/2,
          clean/2]).
 
--define(DEFAULT_PROTO_DIR, "proto").
 -define(DEFAULT_OUT_ERL_DIR, "src").
 -define(DEFAULT_OUT_HRL_DIR, "include").
 
@@ -19,8 +18,6 @@ compile(AppInfo, State) ->
     AppOutDir = rebar_app_info:out_dir(AppInfo),
     Opts = rebar_app_info:opts(AppInfo),
     {ok, GpbOpts0} = dict:find(gpb_opts, Opts),
-    %% check if non-recursive
-    Recursive = proplists:get_value(recursive, GpbOpts0, true),
     SourceDirs = proplists:get_all_values(i, GpbOpts0),
 
 
@@ -38,13 +35,7 @@ compile(AppInfo, State) ->
                     "and \".hrl\" to ~p",
                     [SourceDirs, TargetErlDir, TargetHrlDir]),
     %% search for .proto files
-    FoundProtos = lists:foldl(fun({deps, SourceDir}, Acc) ->
-                                      Acc ++ discover(DepsDir, SourceDir, [{recursive, Recursive}]);
-                                 (SourceDir, Acc) ->
-                                      Acc ++ discover(AppDir, SourceDir, [{recursive, Recursive}])
-                              end, [], SourceDirs),
-    rebar_api:debug("proto files found~s: ~p",
-                    [case Recursive of true -> " recursively"; false -> "" end, FoundProtos]),
+    FoundProtos = find_proto_files(AppDir, DepsDir, GpbOpts0),
 
     Protos = case proplists:get_value(f, GpbOpts0) of
                  undefined ->
@@ -63,7 +54,7 @@ compile(AppInfo, State) ->
                       target_erl_opt(TargetErlDir,
                           target_hrl_opt(TargetHrlDir, GpbOpts0))))),
 
-    compile(Protos, TargetErlDir, GpbOpts, Protos),
+    compile(Protos, GpbOpts, Protos),
     ok.
 
 -spec clean(rebar_app_info:t(),
@@ -81,7 +72,6 @@ clean(AppInfo, State) ->
                                   proplists:get_value(o_hrl, GpbOpts,
                                                       ?DEFAULT_OUT_HRL_DIR)]),
     ProtoFiles = find_proto_files(AppDir, DepsDir, GpbOpts),
-    rebar_api:debug("found proto files: ~p", [ProtoFiles]),
     GeneratedRootFiles =
         lists:usort(
           [filename:rootname(get_target(ProtoFile, GpbOpts))
@@ -97,11 +87,10 @@ clean(AppInfo, State) ->
 %% ===================================================================
 %% Private API
 %% ===================================================================
-discover(AppDir, SourceDir, Opts) ->
+discover(AppDir, SourceDir, Recursive) ->
     %% Convert simple extension to proper regex
     SourceExtRe = "^[^._].*\\" ++ ".proto" ++ [$$],
 
-    Recursive = proplists:get_value(recursive, Opts, true),
     SearchDirectory = filename:join([AppDir, SourceDir]),
     rebar_api:debug("searching .proto files from ~p [recursive=~p]",
                     [SearchDirectory, Recursive]),
@@ -109,13 +98,13 @@ discover(AppDir, SourceDir, Opts) ->
     rebar_utils:find_files(SearchDirectory,
                            SourceExtRe, Recursive).
 
-compile([], _TargetErlDir, _GpbOpts, _Protos) -> ok;
-compile([Proto | Rest], TargetErlDir, GpbOpts, Protos) ->
+compile([], _GpbOpts, _Protos) -> ok;
+compile([Proto | Rest], GpbOpts, Protos) ->
     Target = get_target(Proto, GpbOpts),
     Deps =
       case filelib:last_modified(Target) < filelib:last_modified(Proto) of
           true ->
-            ok = compile(Proto, Target, GpbOpts),
+            ok = do_compile(Proto, Target, GpbOpts),
             %% now we know that this proto needed compilation we check
             %% for other protos that might have included this one and ensure that
             %% those are compiled as well
@@ -139,7 +128,7 @@ compile([Proto | Rest], TargetErlDir, GpbOpts, Protos) ->
           false ->
               []
       end,
-    compile(Rest ++ Deps, TargetErlDir, GpbOpts, Protos).
+    compile(Rest ++ Deps, GpbOpts, Protos).
 
 get_target(Proto, GpbOpts) ->
     InputsOutputs = gpb_compile:list_io(Proto, GpbOpts),
@@ -187,8 +176,8 @@ filter_unwanted_protos(WantedProtos, AllProtos) ->
 
 
 
--spec compile(string(), string(), proplists:proplist()) -> ok.
-compile(Source, Target, GpbOpts) ->
+-spec do_compile(string(), string(), proplists:proplist()) -> ok.
+do_compile(Source, Target, GpbOpts) ->
     rebar_api:debug("compiling ~p to ~p", [Source, Target]),
     rebar_api:debug("opts: ~p", [GpbOpts]),
     case gpb_compile:file(filename:basename(Source), GpbOpts) of
@@ -245,18 +234,25 @@ remove_plugin_opts(Opts0, [OptToRemove | Rest]) ->
     remove_plugin_opts(Opts, Rest).
 
 find_proto_files(AppDir, DepsDir, GpbOpts) ->
-    lists:foldl(fun({deps, SourceDir}, Acc) ->
-                    Acc ++ rebar_utils:find_files(
-                             filename:join(DepsDir, SourceDir),
-                                           ".*\.proto\$");
-                   (SourceDir, Acc) ->
-                    Acc ++ rebar_utils:find_files(
-                             filename:join(AppDir, SourceDir),
-                                           ".*\.proto\$")
-                end,
-                [], proplists:get_all_values(i, GpbOpts)).
+    %% check if non-recursive
+    Recursive = proplists:get_value(recursive, GpbOpts, true),
+    SourceDirs = proplists:get_all_values(i, GpbOpts),
+    FoundProtos = lists:foldl(fun({deps, SourceDir}, Acc) ->
+                                      Acc ++ discover(DepsDir, SourceDir, Recursive);
+                                 (SourceDir, Acc) ->
+                                      Acc ++ discover(AppDir, SourceDir, Recursive)
+                              end, [], SourceDirs),
+    rebar_api:debug("proto files found~s: ~p",
+                    [case Recursive of true -> " recursively"; false -> "" end, FoundProtos]),
+    FoundProtos.
 
 proto_include_paths(_AppDir, [], Opts) -> Opts;
 proto_include_paths(AppDir, [Proto | Protos], Opts) ->
   ProtoDir = filename:join([AppDir, filename:dirname(Proto)]),
-  proto_include_paths(AppDir, Protos, Opts ++ [{i, ProtoDir}]).
+  IncludeProtoDirOpt = {i, ProtoDir},
+  case lists:member(IncludeProtoDirOpt, Opts) of
+      true ->
+          proto_include_paths(AppDir, Protos, Opts);
+      false ->
+          proto_include_paths(AppDir, Protos, Opts ++ [IncludeProtoDirOpt])
+  end.


### PR DESCRIPTION
Refactors proto discovery so compile and clean share the same helper.

Also removes unused compile plumbing and avoids duplicate generated include paths.

Validation:
- `rebar3 compile`
- `rebar3 dialyzer`
- `rebar3 compile` in `doc/samples/sample_app` via `_checkouts`
